### PR TITLE
Refactor user retrieval functions to use email instead of user ID

### DIFF
--- a/api/app/controllers/users.py
+++ b/api/app/controllers/users.py
@@ -22,9 +22,11 @@ def createUser(data):
         raise e
 
 
-def findOneUser(id):
+def findOneUser(email):
     try:
-        return userService.findOneUser(id)
+        fetched = userService.findOneUser(email)
+        if not fetched: raise Exception(f"Usuário {email} não encontrado")
+        return fetched
     except Exception as e:
         print("[CONTROLLER]Error fetching user:", e)
         raise e

--- a/api/app/repository/usersRepository.py
+++ b/api/app/repository/usersRepository.py
@@ -42,14 +42,13 @@ def createUser(data: Users):
         raise e
 
 
-def findOneUser(user_id: ObjectId):
+def findOneUser(email):
     try:
         user_data = users.find_one(
-            {"_id": ObjectId(user_id)}
-
+            {"email": email}
         )
         if not user_data:
-            raise ValueError(f"Nenhum usuário encontrado com o id {user_id}")
+            return None
 
         return Users.from_dict(user_data).to_dict()
     except Exception as e:

--- a/api/app/services/users.py
+++ b/api/app/services/users.py
@@ -11,15 +11,17 @@ def findAllUsers():
 
 def createUser(data):
     try:
+        fetched = findOneUser(data.email)
+        if (fetched): raise Exception("Usuário já existe!") 
         return users.createUser(data)
     except Exception as e:
         print("[SERVICE]Error creating user:", e)
         raise e
 
 
-def findOneUser(id):
+def findOneUser(email):
     try:
-        return users.findOneUser(id)
+        return users.findOneUser(email)
     except Exception as e:
         print("[SERVICE]Error fetching user:", e)
         raise e

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -59,7 +59,6 @@ document.addEventListener("submit", async (event) => {
       type: "console",
       message: `Erro ao chamar a API: ${error.message}`,
     });
-
-    alert("Ocorreu um erro ao chamar o servidor!");
+    alert(error.message);
   }
 });


### PR DESCRIPTION
### Implementação: Impedir E-mails Duplicados na Criação de Usuários

#### Descrição
Este Pull Request adiciona uma validação para evitar que e-mails duplicados sejam cadastrados na aplicação. A nova funcionalidade garante que cada e-mail seja único, promovendo consistência e integridade no sistema.

#### Alterações Realizadas
1. **Backend**:
   - Adicionada verificação no endpoint `/users` para garantir que e-mails duplicados não sejam permitidos.
   - Caso um e-mail duplicado seja detectado, a API retorna uma mensagem de erro apropriada.

2. **Frontend**:
   - Atualizado o fluxo de cadastro de usuários para lidar com a mensagem de erro retornada pela API quando um e-mail duplicado é informado.
   - O usuário será informado via alerta sobre a duplicidade do e-mail.

#### Como Testar
1. Faça login na aplicação.
2. Acesse a página de cadastro de usuários.
3. Tente cadastrar dois usuários com o mesmo e-mail.
4. Verifique se o segundo cadastro é bloqueado com a mensagem de erro.

#### Issue Relacionada
Este Pull Request resolve a [Issue #33](https://github.com/Manoel-Mieiro/ESPEON/issues/33).

#### Capturas de Tela (Opcional)
